### PR TITLE
Set default output of describe-volumes to text

### DIFF
--- a/ebs-snapshot.sh
+++ b/ebs-snapshot.sh
@@ -137,7 +137,7 @@ snapshot_volumes() {
 		log "Volume ID is $volume_id"
 
 		# Get the attched device name to add to the description so we can easily tell which volume this is.
-		device_name=$(aws ec2 describe-volumes --volume-ids $volume_id --query 'Volumes[0].{Devices:Attachments[0].Device}')
+		device_name=$(aws ec2 describe-volumes --output=text --volume-ids $volume_id --query 'Volumes[0].{Devices:Attachments[0].Device}')
 
 		# Take a snapshot of the current volume, and capture the resulting snapshot ID
 		snapshot_description="$(hostname)-$device_name-backup-$(date +%Y-%m-%d)"


### PR DESCRIPTION
The command to get the device name of the volume from EC2 was missing the --output=text, and was causing issues if the default output was set to JSON. Updated the command to include that parameter.