### PR TITLE
Added --region to describe-volumes

### DIFF
--- a/ebs-snapshot.sh
+++ b/ebs-snapshot.sh
@@ -137,7 +137,7 @@ snapshot_volumes() {
 		log "Volume ID is $volume_id"
 
 		# Get the attched device name to add to the description so we can easily tell which volume this is.
-		device_name=$(aws ec2 describe-volumes --output=text --volume-ids $volume_id --query 'Volumes[0].{Devices:Attachments[0].Device}')
+		device_name=$(aws ec2 describe-volumes --region $region --output=text --volume-ids $volume_id --query 'Volumes[0].{Devices:Attachments[0].Device}')
 
 		# Take a snapshot of the current volume, and capture the resulting snapshot ID
 		snapshot_description="$(hostname)-$device_name-backup-$(date +%Y-%m-%d)"


### PR DESCRIPTION
The command to get the device name was failing on servers that were using an IAM role instead of locally stored IAM credentials because the region was missing. Added --region $region to the command so that it gets passed to the command.