### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 aws-ec2-ebs-automatic-snapshot-bash
 ===================================
 
-####Bash script for Automatic EBS Snapshots and Cleanup on Amazon Web Services (AWS)
+#### Bash script for Automatic EBS Snapshots and Cleanup on Amazon Web Services (AWS)
 
 Written by  **[AWS Consultants - Casey Labs Inc.] (http://www.caseylabs.com)**
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
