### PR TITLE
Add volume excludes

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,3 +95,8 @@ To manually test the script:
 ```
 sudo /opt/aws/ebs-snapshot.sh
 ```
+
+One or more volumes can be excluded from snapshots by listing them after the script name as follows:
+```
+sudo /opt/aws/ebs-snapshot.sh vol-6a9f5324 vol-749f533a vol-559f5217
+```

--- a/ebs-snapshot.sh
+++ b/ebs-snapshot.sh
@@ -70,9 +70,9 @@ prerequisite_check() {
 # Function: Check for volumes to exclude from snapshots
 check_for_exclusions() {
 	exclusions=$*
-	if [ -n $exclusions]; then
+	if [ ! -z $exclusions ]; then
 		for exclusion in $exclusions; do
-			volume_list=$($volume_list | grep $exclusions)
+			volume_list=$(echo $volume_list | sed -e "s/$exclusion//")
 		done
 	fi
 }
@@ -125,7 +125,7 @@ log_setup
 prerequisite_check
 
 # Grab all volume IDs attached to this instance
-volume_list=$(aws ec2 describe-volumes --region $region --filters Name=attachment.instance-id,Values=$instance_id --query Volumes[].VolumeId --output text | grep -Ev $1)
+volume_list=$(aws ec2 describe-volumes --region $region --filters Name=attachment.instance-id,Values=$instance_id --query Volumes[].VolumeId --output text)
 
 check_for_exclusions $*
 snapshot_volumes

--- a/ebs-snapshot.sh
+++ b/ebs-snapshot.sh
@@ -67,6 +67,16 @@ prerequisite_check() {
 	done
 }
 
+# Function: Check for volumes to exclude from snapshots
+check_for_exclusions() {
+	exclusions=$*
+	if [ -n $exclusions]; then
+		for exclusion in $exclusions; do
+			volume_list=$($volume_list | grep $exclusions)
+		done
+	fi
+}
+
 # Function: Snapshot all volumes attached to this instance.
 snapshot_volumes() {
 	for volume_id in $volume_list; do
@@ -115,7 +125,8 @@ log_setup
 prerequisite_check
 
 # Grab all volume IDs attached to this instance
-volume_list=$(aws ec2 describe-volumes --region $region --filters Name=attachment.instance-id,Values=$instance_id --query Volumes[].VolumeId --output text)
+volume_list=$(aws ec2 describe-volumes --region $region --filters Name=attachment.instance-id,Values=$instance_id --query Volumes[].VolumeId --output text | grep -Ev $1)
 
+check_for_exclusions $*
 snapshot_volumes
 cleanup_snapshots

--- a/ebs-snapshot.sh
+++ b/ebs-snapshot.sh
@@ -20,7 +20,7 @@ set -o pipefail
 # - Take a snapshot of each attached volume
 # - The script will then delete all associated snapshots taken by the script that are older than 7 days
 #
-# DISCLAIMER: This script deletes snapshots (though only the ones that it creates). 
+# DISCLAIMER: This script deletes snapshots (though only the ones that it creates).
 # Make sure that you understand how the script works. No responsibility accepted in event of accidental data loss.
 #
 
@@ -80,7 +80,7 @@ snapshot_volumes() {
 
 		snapshot_id=$(aws ec2 create-snapshot --region $region --output=text --description $snapshot_description --volume-id $volume_id --query SnapshotId)
 		log "New snapshot is $snapshot_id"
-	 
+
 		# Add a "CreatedBy:AutomatedBackup" tag to the resulting snapshot.
 		# Why? Because we only want to purge snapshots taken by the script later, and not delete snapshots manually taken.
 		aws ec2 create-tags --region $region --resource $snapshot_id --tags Key=CreatedBy,Value=AutomatedBackup
@@ -106,7 +106,7 @@ cleanup_snapshots() {
 			fi
 		done
 	done
-}	
+}
 
 
 ## SCRIPT COMMANDS ##

--- a/ebs-snapshot.sh
+++ b/ebs-snapshot.sh
@@ -70,7 +70,7 @@ prerequisite_check() {
 # Function: Check for volumes to exclude from snapshots
 check_for_exclusions() {
 	exclusions=$*
-	if [ ! -z $exclusions ]; then
+	if [ -n "$exclusions" ]; then
 		for exclusion in $exclusions; do
 			volume_list=$(echo $volume_list | sed -e "s/$exclusion//")
 		done


### PR DESCRIPTION
We have a use case where we would like to exclude one or more volumes from snapshots.

This PR modifies the ebs-snapshot.sh script to accept one or more volume id's to exclude from being snapshotted at all. The READM has been updated with an example of how to do this.